### PR TITLE
Erstellung einer CI/CD-Pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,6 @@
+name: Java CI Build and Artifact Upload
+
+on:
+  push:
+    branches:
+      - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,3 +11,19 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+
+      - name: Set up JDK 22
+        uses: actions/setup-java@v2
+        with:
+          java-version: '22'
+          distribution: 'temurin'
+
+      - name: Build with Maven
+        run: mvn clean package
+        working-directory: ./
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+            name: TicTacToeGame-GroupE
+            path: target/TicTacToeGame-GroupE-1.0-SNAPSHOT.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+
+  pull_request:
+      branches:
+        - main
 jobs:
   build-and-upload-artifact:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,3 +4,10 @@ on:
   push:
     branches:
       - main
+jobs:
+  build-and-upload-artifact:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2


### PR DESCRIPTION

Das ist der erste Pull-Request für dieses Projekt und zeigt die CI/CD-Pipeline-Konfiguration. 
**Details zur CI/CD-Pipeline:**

- Führt automatisierte Tests und Builds aus, wenn Code in den Main-Branch gepusht wird oder ein Pull-Request gestellt wird, der auf den Main-Branch abzielt.
- Stellt sicher, dass die Codequalität erhalten bleibt, indem Tests durchgeführt werden, bevor Änderungen in den Main-Branch übernommen werden.
- Erstellt das Projekt mit Maven und lädt die Build-Artefakte zur weiteren Verwendung hoch.

Die Pipeline umfasst Schritte zum Auschecken des Repositorys, zum Einrichten von JDK 22,
 zum Erstellen des Projekts mit Maven und zum Hochladen des Build-Artefakts. 
Dadurch wird sichergestellt, dass der Main-Branch in einem stabilen und funktionsfähigen Zustand bleibt, 
und hilft, Fehler frühzeitig im Entwicklungsprozess zu erkennen.